### PR TITLE
Add Title to MediaMetadataCompat data

### DIFF
--- a/rxmusicplayer/src/main/java/com/orfium/rx/musicplayer/media/MediaService.kt
+++ b/rxmusicplayer/src/main/java/com/orfium/rx/musicplayer/media/MediaService.kt
@@ -121,6 +121,7 @@ internal class MediaService: Service(), Playback.ServiceCallback {
         return MediaMetadataCompat.Builder()
             .putString(MediaMetadataCompat.METADATA_KEY_ART_URI, media?.image)
             .putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_TITLE, media?.title)
+            .putString(MediaMetadataCompat.METADATA_KEY_TITLE, media?.title)
             .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, media?.artist)
             .putString(MediaMetadataCompat.METADATA_KEY_MEDIA_URI, media?.streamUrl)
             .putString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID, media?.id?.toString())


### PR DESCRIPTION
The Samsung lock screen is using the title value instead of properly displaying the display title