### PR TITLE
[PRAY-3964] Fix crash when opening Audio Player on some devices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
         // App version
         versionCode = 2
-        versionName = "1.1.0.4"
+        versionName = "1.1.0.5"
 
         // Kotlin
         kotlinVersion = "1.3.72"

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         versionName = "1.1.0.5"
 
         // Kotlin
-        kotlinVersion = "1.3.72"
+        kotlinVersion = "1.4.0"
 
         // AndroidX
         appcompatVersion = "1.3.0-alpha01"

--- a/rxmusicplayer/build.gradle
+++ b/rxmusicplayer/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
-apply plugin: "com.github.dcendents.android-maven"
+apply plugin: "maven-publish"
 
-group="com.github.Orfium"
+group = "com.github.praycom"
 version = rootProject.versionName
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
-
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -26,6 +25,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }
 
 dependencies {
@@ -39,4 +41,21 @@ dependencies {
 
     testImplementation "junit:junit:$rootProject.junitVersion"
     testImplementation "org.mockito:mockito-core:$rootProject.mockitoVersion"
+}
+
+task sourcesJar(type: Jar) {
+    classifier "source"
+    from android.sourceSets.main.java.srcDirs
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                artifactId = "RxMusicPlayer-android"
+                from components.release
+                artifact sourcesJar
+            }
+        }
+    }
 }

--- a/rxmusicplayer/src/main/java/com/orfium/rx/musicplayer/RxMusicPlayer.kt
+++ b/rxmusicplayer/src/main/java/com/orfium/rx/musicplayer/RxMusicPlayer.kt
@@ -17,6 +17,14 @@ object RxMusicPlayer {
     private val actionSubject = PublishSubject.create<Action>()
     private val playbackPositionSubject = PublishSubject.create<Long>()
 
+    var notificationIconRes: Int = R.mipmap.ic_notification_small
+        private set
+
+    @JvmStatic
+    fun setNotificationIconRes(notificationIconRes: Int) {
+        this.notificationIconRes = notificationIconRes
+    }
+
     @JvmStatic
     fun start(context: Context, intent: Intent? = null) {
         ContextCompat.startForegroundService(

--- a/rxmusicplayer/src/main/java/com/orfium/rx/musicplayer/notification/NotificationManager.kt
+++ b/rxmusicplayer/src/main/java/com/orfium/rx/musicplayer/notification/NotificationManager.kt
@@ -21,6 +21,7 @@ import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import com.orfium.rx.musicplayer.R
+import com.orfium.rx.musicplayer.RxMusicPlayer
 import com.orfium.rx.musicplayer.common.PlaybackState
 import com.orfium.rx.musicplayer.media.Media
 import com.orfium.rx.musicplayer.media.MediaService
@@ -29,7 +30,7 @@ internal class NotificationManager(
     private val service: Service,
     private val token: MediaSessionCompat.Token,
     private val notificationManager: NotificationManagerCompat,
-    private var notificationIconRes: Int = R.mipmap.ic_notification_small
+    private var notificationIconRes: Int = RxMusicPlayer.notificationIconRes
 ) {
 
     companion object {
@@ -186,15 +187,9 @@ internal class NotificationManager(
     }
 
     private fun showNotification(builder: NotificationCompat.Builder, bitmap: Bitmap?) {
-
-        if (media == null || state == PlaybackState.Idle) {
-            return
-        }
-
         builder.setStyle(
             androidx.media.app.NotificationCompat.MediaStyle()
                 .setMediaSession(token)
-                .setShowActionsInCompactView(0, 1, 2)
             )
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -202,11 +197,17 @@ internal class NotificationManager(
             .setSmallIcon(notificationIconRes)
             .setShowWhen(false)
             .setOnlyAlertOnce(true)
-            .setContentTitle(media?.title)
+            .setContentTitle(media?.title ?: service.getString(R.string.player_initialization))
             .setContentText(media?.artist)
             .setDeleteIntent(dismiss(service))
 
         if (state !is PlaybackState.Idle) {
+            builder.setStyle(
+                androidx.media.app.NotificationCompat.MediaStyle()
+                    .setMediaSession(token)
+                    .setShowActionsInCompactView(0, 1, 2)
+            )
+
             builder.addAction(prev(service))
 
             if (state is PlaybackState.Paused || state is PlaybackState.Completed) {

--- a/rxmusicplayer/src/main/java/com/orfium/rx/musicplayer/notification/NotificationManager.kt
+++ b/rxmusicplayer/src/main/java/com/orfium/rx/musicplayer/notification/NotificationManager.kt
@@ -186,6 +186,11 @@ internal class NotificationManager(
     }
 
     private fun showNotification(builder: NotificationCompat.Builder, bitmap: Bitmap?) {
+
+        if (media == null || state == PlaybackState.Idle) {
+            return
+        }
+
         builder.setStyle(
             androidx.media.app.NotificationCompat.MediaStyle()
                 .setMediaSession(token)

--- a/rxmusicplayer/src/main/res/values/strings.xml
+++ b/rxmusicplayer/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">RxMusicPlayer</string>
+    <string name="player_initialization">Player initialization&#8230;</string>
 </resources>


### PR DESCRIPTION
https://prayinc.atlassian.net/browse/PRAY-3964
- Add back old guard against null `media` and `PlaybackState.Idle` before modifying Notification
- increment version

Here was the exception:
`2020-08-18 11:15:38.946 4732-4732/com.prayapp.client E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.prayapp.client, PID: 4732
    android.app.RemoteServiceException: Bad notification(tag=null, id=100) posted from package com.prayapp.client, crashing app(uid=10379, pid=4732): Couldn't inflate contentViewsjava.lang.IllegalArgumentException: setShowActionsInCompactView: action 0 out of bounds (max -1)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1745)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6735)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)`

What happened was after the last changes if the `PlaybackState` was `Idle` the notification was told it would have Actions at indices 0, 1, and 2, but no Actions were added. 

So I added back the check to exit the method if the `PlaybackState` is `Idle`. 